### PR TITLE
perf: syntax highlighting searches the saved state list from the start

### DIFF
--- a/runtime/doc/testing.txt
+++ b/runtime/doc/testing.txt
@@ -409,6 +409,8 @@ test_override({name}, {val})				*test_override()*
 		redraw       disable the redrawing() function.
 		redraw_flag  ignore the RedrawingDisabled flag.
 		starting     reset the "starting" variable, see below.
+		syn_stack_hint	disable the search hint for the saved syntax
+				state, so the list is scanned from the start.
 		term_props   reset all terminal properties when the version
 			     string is detected.
 		ui_delay     time in msec to use in ui_delay(); overrules a

--- a/src/globals.h
+++ b/src/globals.h
@@ -2007,6 +2007,7 @@ EXTERN int  disable_char_avail_for_testing INIT(= FALSE);
 EXTERN int  disable_redraw_for_testing INIT(= FALSE);
 EXTERN int  ignore_redraw_flag_for_testing INIT(= FALSE);
 EXTERN int  nfa_fail_for_testing INIT(= FALSE);
+EXTERN int  disable_syn_stack_hint_for_testing INIT(= FALSE);
 EXTERN int  no_query_mouse_for_testing INIT(= FALSE);
 EXTERN int  ui_delay_for_testing INIT(= 0);
 EXTERN int  reset_term_props_on_termresponse INIT(= FALSE);

--- a/src/structs.h
+++ b/src/structs.h
@@ -3191,6 +3191,9 @@ typedef struct {
     synstate_T	*b_sst_first;
     synstate_T	*b_sst_firstfree;
     int		b_sst_freecount;
+    synstate_T	*b_sst_lastfound;	// last entry returned by
+					// syn_stack_find_entry(), used as a
+					// search hint; NULL when invalid
     linenr_T	b_sst_check_lnum;
     short_u	b_sst_lasttick;	// last display tick
 #endif // FEAT_SYN_HL

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -1034,6 +1034,7 @@ syn_stack_free_block(synblock_T *block)
 	clear_syn_state(p);
     VIM_CLEAR(block->b_sst_array);
     block->b_sst_first = NULL;
+    block->b_sst_lastfound = NULL;
     block->b_sst_len = 0;
 }
 /*
@@ -1125,6 +1126,8 @@ syn_stack_alloc(void)
 	    syn_block->b_sst_first = NULL;
 	    syn_block->b_sst_freecount = len;
 	}
+	// The entries moved to a new array, drop the stale search hint.
+	syn_block->b_sst_lastfound = NULL;
 
 	// Create the list of free entries.
 	syn_block->b_sst_firstfree = to + 1;
@@ -1275,6 +1278,8 @@ syn_stack_cleanup(void)
 syn_stack_free_entry(synblock_T *block, synstate_T *p)
 {
     clear_syn_state(p);
+    if (block->b_sst_lastfound == p)
+	block->b_sst_lastfound = NULL;	// don't keep a freed search hint
     p->sst_next = block->b_sst_firstfree;
     block->b_sst_firstfree = p;
     ++block->b_sst_freecount;
@@ -1288,15 +1293,29 @@ syn_stack_free_entry(synblock_T *block, synstate_T *p)
 syn_stack_find_entry(linenr_T lnum)
 {
     synstate_T	*p, *prev;
+    synstate_T	*start = syn_block->b_sst_first;
+
+    // The list is sorted by line number, so when the last found entry is at or
+    // before "lnum" the wanted entry cannot be before it: start searching there
+    // instead of at the head.
+    if (!disable_syn_stack_hint_for_testing
+	    && syn_block->b_sst_lastfound != NULL
+	    && syn_block->b_sst_lastfound->sst_lnum <= lnum)
+	start = syn_block->b_sst_lastfound;
 
     prev = NULL;
-    for (p = syn_block->b_sst_first; p != NULL; prev = p, p = p->sst_next)
+    for (p = start; p != NULL; prev = p, p = p->sst_next)
     {
 	if (p->sst_lnum == lnum)
+	{
+	    syn_block->b_sst_lastfound = p;
 	    return p;
+	}
 	if (p->sst_lnum > lnum)
 	    break;
     }
+    if (prev != NULL)
+	syn_block->b_sst_lastfound = prev;
     return prev;
 }
 

--- a/src/testdir/test_syntax.vim
+++ b/src/testdir/test_syntax.vim
@@ -689,6 +689,49 @@ func Test_syn_zsub()
   bw!
 endfunc
 
+" Collect the syntax id name of every cell of a freshly highlighted buffer.
+func s:SynDumpBuffer(ft, lines)
+  new
+  syntax on
+  execute 'setfiletype ' .. a:ft
+  call setline(1, a:lines)
+  let l:result = []
+  for lnum in range(1, line('$'))
+    for col in range(1, max([1, len(getline(lnum))]))
+      call add(l:result, synIDattr(synID(lnum, col, 1), 'name'))
+    endfor
+  endfor
+  bwipe!
+  return l:result
+endfunc
+
+" The saved-state search hint is a speed optimization only: highlighting must
+" be identical whether syn_stack_find_entry() starts from the cached last entry
+" (default) or scans from the start.  Use tall buffers so the state stack holds
+" many entries and the hint is exercised, evicted and rebuilt while looking up
+" lines in increasing order.
+func Test_syntax_stack_hint_unchanged()
+  let samples = {
+        \ 'c': ['#define M 0x1F', "char c = '\\n';",
+        \       'int f(int a) { return a + 0xAB; }', '/* a comment',
+        \       '   that spans lines */', 'L"wide"'],
+        \ 'vim': ['func <SID>Foo() abort', '  let x = [1, 2] + {"k": 0z1f}',
+        \         '  " a comment', 'endfunc'],
+        \ }
+  for ft in sort(keys(samples))
+    let lines = []
+    for i in range(40)
+      call extend(lines, samples[ft])
+    endfor
+    call test_override('syn_stack_hint', 0)
+    let l:on = s:SynDumpBuffer(ft, lines)
+    call test_override('syn_stack_hint', 1)
+    let l:off = s:SynDumpBuffer(ft, lines)
+    call test_override('ALL', 0)
+    call assert_equal(l:off, l:on, 'filetype ' .. ft)
+  endfor
+endfunc
+
 " Using \z() in a region with NFA failing should not crash.
 func Test_syn_wrong_z_one()
   new

--- a/src/testing.c
+++ b/src/testing.c
@@ -1055,6 +1055,8 @@ f_test_override(typval_T *argvars, typval_T *rettv UNUSED)
     }
     else if (STRCMP(name, (char_u *)"nfa_fail") == 0)
 	nfa_fail_for_testing = val;
+    else if (STRCMP(name, (char_u *)"syn_stack_hint") == 0)
+	disable_syn_stack_hint_for_testing = val;
     else if (STRCMP(name, (char_u *)"no_query_mouse") == 0)
 	no_query_mouse_for_testing = val;
     else if (STRCMP(name, (char_u *)"no_wait_return") == 0)
@@ -1081,6 +1083,7 @@ f_test_override(typval_T *argvars, typval_T *rettv UNUSED)
 	disable_redraw_for_testing = FALSE;
 	ignore_redraw_flag_for_testing = FALSE;
 	nfa_fail_for_testing = FALSE;
+	disable_syn_stack_hint_for_testing = FALSE;
 	no_query_mouse_for_testing = FALSE;
 	ui_delay_for_testing = 0;
 	reset_term_props_on_termresponse = FALSE;


### PR DESCRIPTION
```
Problem:  Looking up the saved syntax state for a line scans the state
          list from the start every time, which is slow when highlighting
          a large file in increasing line order.
Solution: Remember the last found entry and start the search there when it
          is at or before the wanted line; the list is sorted, so the
          result cannot be earlier.  The highlighting is unchanged.
```